### PR TITLE
Support Kakao button without styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,22 @@ ReactDOM.render(
   />, appRoot
 );
 ```
+
+### Kakao button without styling
+
+If you're providing all your own custom styling, you can use the render prop build. This build doesn't include any CSS or additional code needed to customise the look of the button, and instead leaves that entirely up to you.
+
+```js
+<KakaoLogin
+  jsKey="4a5607f2dc1622d91b7137fff35a464d"
+  onSuccess={success}
+  onFailure={failure}
+  render={renderProps => (
+    <button onClick={renderProps.onClick}>This is my custom kakao button</button>
+  )}
+/>, appRoot
+```
+
+The `render` function will be passed the following properties for you to use:
+
+- `onClick`

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If you're providing all your own custom styling, you can use the render prop bui
   render={renderProps => (
     <button onClick={renderProps.onClick}>This is my custom kakao button</button>
   )}
-/>, appRoot
+/>
 ```
 
 The `render` function will be passed the following properties for you to use:

--- a/src/kakao.jsx
+++ b/src/kakao.jsx
@@ -67,6 +67,14 @@ export default class KakaoLogin extends PureComponent {
   }
 
   render() {
+    const { buttonClass, buttonComponent, buttonText, children, render } = this.props;
+
+    if (render && typeof render === 'function') {
+      return render({
+        onClick: this.onBtnClick,
+      });
+    }
+
     const style = {
       display: 'inline-block',
       padding: '0',
@@ -80,8 +88,6 @@ export default class KakaoLogin extends PureComponent {
       fontSize: '16px',
       textAlign: 'center',
     };
-
-    const { buttonClass, buttonComponent, buttonText, children } = this.props;
 
     return (
       <button


### PR DESCRIPTION
- To support `render` props for fully customized button