### PR TITLE
OIDC 토큰 추가, 일부 interface export

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,16 @@
 import { CSSProperties, ReactChild, ReactNode } from "react";
-interface KakaoError {
+export interface KakaoError {
   error: string;
   error_description: string;
 }
 
-interface LoginResponse {
+export interface LoginResponse {
   /** 토큰 타입, bearer 로 고정 */
   token_type: string;
   /** 사용자 액세스 토큰 값 */
   access_token: string;
+  /** OIDC 토큰 값 */
+  id_token?: string;
   /** 액세스 토큰 만료 시간(초) */
   expires_in: string;
   /** 사용자 리프레시 토큰 값 */
@@ -71,7 +73,7 @@ interface KakaoAccount {
   ci: string;
 }
 
-interface UserProfile {
+export interface UserProfile {
   /** 회원번호 */
   id: number;
   /** 카카오계정 정보 */


### PR DESCRIPTION
Kakao OAuth v2에서 부터는 OpenID Connect(OIDC)를 지원하고 있습니다.
리턴값도 정상적으로 들어오지만, type에 OIDC가 없어서 id_token을 추가해두었습니다.

추가로, 주입하는 함수(onSuccess, onFail)를 외부에서 선언 하는 경우를 위해서 함수에서 사용하는 LoginResponse와 UserProfile, KakaoError에 export를 추가하여 다른 파일에서도 사용할 수 있도록 해두었습니다.

확인 후 merge 해주시면 감사드리겠습니다 :)

= Kakao OAuth 관련 문서
https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token